### PR TITLE
 🔀 :: [#47] 게시글 작성 페이지 수정

### DIFF
--- a/Projects/App/Sources/Feature/DetailFeature/Views/ItemDetailView.swift
+++ b/Projects/App/Sources/Feature/DetailFeature/Views/ItemDetailView.swift
@@ -76,6 +76,7 @@ struct ItemDetailView: View {
                     VStack(alignment: .leading, spacing: 24) {
                         Text(item.title)
                             .gwangsanFont(style: .titleSmall)
+                            .padding(.top, 20)
 
                         Text("\(item.point) 광산")
                             .gwangsanFont(style: .body3)

--- a/Projects/App/Sources/Feature/HomeFeature/ViewModel/PostDraftViewModel.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/ViewModel/PostDraftViewModel.swift
@@ -13,11 +13,15 @@ class PostDraftViewModel: ObservableObject {
     @Published var topic: String = ""
     @Published var content: String = ""
     @Published var point: String = ""
-    @Published var selectedImages: [UIImage] = []
+    @Published var selectedImages: [UIImage] = [] // 이미지 전달 상태 변경해야함
+    @Published var mode: CommonItem.Mode = .service
+    @Published var category: CommonItem.Category = .request
     
     func sumbit() {
-        print("\(topic)")
-        print("\(content)")
-        print("\(point)")
+        print("주제: \(topic)")
+        print("내용: \(content)")
+        print("광산: \(point)")
+        print("모드: \(mode)")
+        print("카테고리: \(category)")
     }
 }

--- a/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep1View.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep1View.swift
@@ -27,7 +27,9 @@ struct PostCreateStep1View: View {
             
             ZStack {
                 HStack {
-                    Image("Back")
+                    Button(action: { dismiss() }) {
+                        Image("Back")
+                    }
                     Spacer()
                     Text("\(headerTitle)")
                         .gwangsanFont(style: .body1)
@@ -36,7 +38,7 @@ struct PostCreateStep1View: View {
                 
                 HStack {
                     Spacer()
-                    Button(action: { dismiss() }) {
+                    NavigationLink(destination: MainView()) {
                         Image("Close")
                             .resizable()
                             .frame(width: 25, height: 25)
@@ -145,7 +147,7 @@ struct PostCreateStep1View: View {
                     horizontalPadding: 0,
                     height: 52,
                     style: .filled,
-                    destination: PostCreateStep2View(viewModel: viewModel)
+                    destination: PostCreateStep2View(headerTitle: headerTitle, viewModel: viewModel)
                 )
                 .padding(.bottom, 30)
             }

--- a/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep2View.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep2View.swift
@@ -16,7 +16,6 @@ struct PostCreateStep2View: View {
     
     var body: some View {
         NavigationStack{
-            
             ZStack {
                 HStack {
                     Button(action: { dismiss() }) {

--- a/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep2View.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep2View.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct PostCreateStep2View: View {
+    let headerTitle: String
     @ObservedObject var viewModel: PostDraftViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var showError: Bool = false
@@ -16,25 +17,27 @@ struct PostCreateStep2View: View {
     var body: some View {
         NavigationStack{
             
-                ZStack {
-                    HStack {
+            ZStack {
+                HStack {
+                    Button(action: { dismiss() }) {
                         Image("Back")
-                        Spacer()
-                        Text("필요해요")
-                            .gwangsanFont(style: .body1)
-                        Spacer()
                     }
-                    
-                    HStack {
-                        Spacer()
-                        Button(action: { dismiss() }) {
-                            Image("Close")
-                                .resizable()
-                                .frame(width: 25, height: 25)
-                        }
+                    Spacer()
+                    Text("\(headerTitle)")
+                        .gwangsanFont(style: .body1)
+                    Spacer()
+                }
+                
+                HStack {
+                    Spacer()
+                    NavigationLink(destination: MainView()) {
+                        Image("Close")
+                            .resizable()
+                            .frame(width: 25, height: 25)
                     }
                 }
-                .padding(.horizontal, 24)
+            }
+            .padding(.horizontal, 24)
             
             ProgressBar(currentStep: 2)
             
@@ -59,7 +62,7 @@ struct PostCreateStep2View: View {
                     horizontalPadding: 0,
                     height: 52,
                     style: .filled,
-                    destination: PostCreateStep3View(viewModel: viewModel)
+                    destination: PostCreateStep3View(headerTitle: headerTitle, viewModel: viewModel)
                 )
                 .padding(.bottom, 30)
             }

--- a/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep3View.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep3View.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct PostCreateStep3View: View {
+    let headerTitle: String
     @Environment(\.dismiss) private var dismiss
     @FocusState private var isFocused: Bool
     @ObservedObject var viewModel: PostDraftViewModel
@@ -22,7 +23,7 @@ struct PostCreateStep3View: View {
                 HStack {
                     Image("Back")
                     Spacer()
-                    Text("필요해요")
+                    Text(headerTitle)
                         .gwangsanFont(style: .body1)
                     Spacer()
                 }

--- a/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep3View.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Views/PostCratePage/PostCreateStep3View.swift
@@ -15,22 +15,23 @@ struct PostCreateStep3View: View {
     @ObservedObject var viewModel: PostDraftViewModel
     @State private var navigateToStep1 = false
     @State private var showError: Bool = false
-    
+
     var body: some View {
         NavigationStack {
-            
             ZStack {
                 HStack {
-                    Image("Back")
+                    Button(action: { dismiss() }) {
+                        Image("Back")
+                    }
                     Spacer()
-                    Text(headerTitle)
+                    Text("\(headerTitle)")
                         .gwangsanFont(style: .body1)
                     Spacer()
                 }
                 
                 HStack {
                     Spacer()
-                    Button(action: { dismiss() }) {
+                    NavigationLink(destination: MainView()) {
                         Image("Close")
                             .resizable()
                             .frame(width: 25, height: 25)
@@ -38,16 +39,16 @@ struct PostCreateStep3View: View {
                 }
             }
             .padding(.horizontal, 24)
-            
+
             ProgressBar(currentStep: 3)
-            
+
             VStack(spacing: 0) {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         Text("다시 한번 확인해주세요.")
                             .gwangsanFont(style: .titleSmall)
                             .padding(.top, 10)
-                        
+
                         GwangsanTextField(
                             "이름을 입력해주세요",
                             text: $viewModel.topic,
@@ -59,11 +60,11 @@ struct PostCreateStep3View: View {
                             }
                         )
                         .padding(.top, 30)
-                        
+
                         VStack(alignment: .leading, spacing: 5) {
                             Text("내용")
                                 .gwangsanFont(style: .label)
-                            
+
                             ZStack(alignment: .topLeading) {
                                 TextEditor(text: $viewModel.content)
                                     .font(.system(size: 14))
@@ -81,7 +82,7 @@ struct PostCreateStep3View: View {
                                     )
                                     .cornerRadius(8)
                                     .focused($isFocused)
-                                
+
                                 if viewModel.content.isEmpty {
                                     Text("내용을 작성해주세요")
                                         .font(.system(size: 14))
@@ -91,11 +92,11 @@ struct PostCreateStep3View: View {
                             }
                         }
                         .padding(.top, 25)
-                        
+
                         VStack(alignment: .leading, spacing: 8) {
                             Text("사진첨부")
                                 .gwangsanFont(style: .label)
-                            
+
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 16) {
                                     ForEach(viewModel.selectedImages, id: \.self) { image in
@@ -109,7 +110,7 @@ struct PostCreateStep3View: View {
                             }
                         }
                         .padding(.top, 10)
-                        
+
                         GwangsanTextField(
                             "광산을 입력해주세요",
                             text: $viewModel.point,
@@ -121,15 +122,15 @@ struct PostCreateStep3View: View {
                             }
                         )
                         .padding(.top, 30)
-                        
+
                         HStack(spacing: 12) {
                             NavigationLink(destination: PostCreateStep1View(
-                                headerTitle: "필요해요",
+                                headerTitle: headerTitle,
                                 viewModel: viewModel
                             ), isActive: $navigateToStep1) {
                                 EmptyView()
                             }.hidden()
-                            
+
                             GwangsanButton(
                                 text: "수정",
                                 buttonState: true,
@@ -139,17 +140,16 @@ struct PostCreateStep3View: View {
                             ) {
                                 navigateToStep1 = true
                             }
-                            
+
                             GwangsanButton(
                                 text: "완료",
                                 buttonState: true,
                                 horizontalPadding: 0,
                                 height: 52,
-                                style: .filled,
-                                action: {
-                                    viewModel.sumbit()
-                                }
-                            )
+                                style: .filled
+                            ) {
+                                viewModel.sumbit()
+                            }
                         }
                         .padding(.top, 60)
                         .padding(.bottom, 20)
@@ -159,5 +159,23 @@ struct PostCreateStep3View: View {
             }
         }
         .navigationBarHidden(true)
+        .onAppear {
+            switch headerTitle {
+            case "해주세요":
+                viewModel.mode = .service
+                viewModel.category = .request
+            case "할수있어요":
+                viewModel.mode = .service
+                viewModel.category = .provide
+            case "필요해요":
+                viewModel.mode = .item
+                viewModel.category = .request
+            case "팔아요":
+                viewModel.mode = .item
+                viewModel.category = .provide
+            default:
+                break
+            }
+        }
     }
 }

--- a/Projects/App/Sources/Feature/HomeFeature/Views/ServiceListView.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Views/ServiceListView.swift
@@ -181,7 +181,3 @@ struct ServiceListView: View {
 #Preview {
     ServiceListView()
 }
-
-#Preview {
-    ServiceListView()
-}

--- a/Projects/App/Sources/Feature/ProfileFeature/Views/MyPostDetailView.swift
+++ b/Projects/App/Sources/Feature/ProfileFeature/Views/MyPostDetailView.swift
@@ -76,6 +76,7 @@ struct MyPostDetailView: View {
                     VStack(alignment: .leading, spacing: 24) {
                         Text(item.title)
                             .gwangsanFont(style: .titleSmall)
+                            .padding(.top, 20)
 
                         Text("\(item.point) 광산")
                             .gwangsanFont(style: .body3)

--- a/Projects/App/Sources/Feature/ProfileFeature/Views/MyPostDetailView.swift
+++ b/Projects/App/Sources/Feature/ProfileFeature/Views/MyPostDetailView.swift
@@ -1,0 +1,130 @@
+//
+//  MyPostDetailView.swift
+//  Gwangsan
+//
+//  Created by 박정우 on 6/26/25.
+//  Copyright © 2025 schoolcompany. All rights reserved.
+//
+
+import SwiftUI
+
+struct MyPostDetailView: View {
+    let item: CommonItem
+    @Environment(\.dismiss) private var dismiss
+    @State private var isReportSheetPresented = false
+    @State private var isReviewSheetPresented = false
+
+    var categoryText: String {
+        item.category.displayName(for: item.mode)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                ZStack {
+                    Text(item.mode == .service ? "서비스" : "물건")
+                        .gwangsanFont(style: .body1)
+
+                    HStack {
+                        Button(action: { dismiss() }) {
+                            Image(systemName: "chevron.left")
+                                .frame(width: 24, height: 24)
+                                .gwangsanColor(GwangsanAsset.Color.gray500)
+                        }
+                        Spacer()
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 10)
+
+                Image(item.imageName)
+                    .resizable()
+                    .frame(height: 280)
+                    .frame(maxWidth: .infinity)
+
+                HStack(alignment: .center) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "person.crop.circle.fill")
+                            .resizable()
+                            .frame(width: 48, height: 48)
+                            .foregroundColor(.gray)
+                            .clipShape(Circle())
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("모태환")
+                                .gwangsanFont(style: .body3)
+
+                            Text("첨단 1동")
+                                .font(.system(size: 14))
+                                .foregroundColor(.gray)
+                        }
+                    }
+                    .padding(.vertical, 10)
+
+                    Spacer()
+
+                    Text("8단계")
+                        .gwangsanFont(style: .body1)
+                        .gwangsanColor(GwangsanAsset.Color.mainYellow500)
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 6)
+
+                Divider()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        Text(item.title)
+                            .gwangsanFont(style: .titleSmall)
+
+                        Text("\(item.point) 광산")
+                            .gwangsanFont(style: .body3)
+
+                        Text(item.content)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 20)
+                }
+
+                HStack(spacing: 12){
+                    GwangsanButton(
+                        text: "채팅하기",
+                        fontSize: 14,
+                        buttonState: true,
+                        horizontalPadding: 0,
+                        height: 52,
+                        style: .outline,
+                        destination: SwiftUIView()
+                    )
+
+                    GwangsanButton(
+                        text: "거래완료",
+                        fontSize: 14,
+                        buttonState: true,
+                        horizontalPadding: 0,
+                        height: 52,
+                        style: .filled,
+                        action: {
+                            isReviewSheetPresented = true
+                        }
+                    )
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 25)
+            }
+            .navigationBarHidden(true)
+            .sheet(isPresented: $isReportSheetPresented) {
+                ReportSheetView()
+                    .presentationDetents([.fraction(0.8)])
+                    .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $isReviewSheetPresented) {
+                ReviewSheetView()
+                    .presentationDetents([.fraction(0.8)])
+                    .presentationDragIndicator(.visible)
+            }
+        }
+    }
+}

--- a/Projects/App/Sources/Feature/ProfileFeature/Views/MyPostsView.swift
+++ b/Projects/App/Sources/Feature/ProfileFeature/Views/MyPostsView.swift
@@ -116,9 +116,9 @@ struct MyPostsView: View {
                     Spacer()
                 }
             }
+            .padding(.horizontal, 24)
             .navigationBarHidden(true)
         }
-        .padding(.horizontal, 24)
     }
 }
 

--- a/Projects/App/Sources/Feature/ProfileFeature/Views/MyPostsView.swift
+++ b/Projects/App/Sources/Feature/ProfileFeature/Views/MyPostsView.swift
@@ -8,38 +8,48 @@
 
 import SwiftUI
 
-struct MyPostItem: Identifiable {
-    let id = UUID()
-    let imageName: String
-    let title: String
-    let point: Int
-    let category: String
-}
-
 struct MyPostsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var selectedCategory = ""
     @State private var selectedType = ""
-
-    let items: [MyPostItem] = [
-        MyPostItem(imageName: "TestImage1", title: "바퀴벌레 좀 잡아주세요", point: 3000, category: "서비스"),
-        MyPostItem(imageName: "TestImage2", title: "집 청소좀 해주세요", point: 3000, category: "서비스"),
-        MyPostItem(imageName: "TestImage3", title: "자전거 팔아요", point: 5000, category: "팔아요")
+    
+    let items: [CommonItem] = [
+        CommonItem(id: UUID(), title: "바퀴벌레 좀 잡아주세요", point: 3000, category: .request, imageName: "TestImage1", content: "바퀴벌레 요청", mode: .service),
+        CommonItem(id: UUID(), title: "집 청소좀 해주세요", point: 3000, category: .request, imageName: "TestImage2", content: "집 청소 요청", mode: .service),
+        CommonItem(id: UUID(), title: "자전거 팔아요", point: 5000, category: .provide, imageName: "TestImage3", content: "자전거 판매", mode: .item)
     ]
-
-    var filteredItems: [MyPostItem] {
+    
+    var filteredItems: [CommonItem] {
         items.filter { item in
-            (selectedCategory.isEmpty || item.category == selectedCategory)
+            let categoryMatches = selectedCategory.isEmpty ||
+            (selectedCategory == "서비스" && item.mode == .service) ||
+            (selectedCategory == "물건" && item.mode == .item)
+            
+            let typeMatches = selectedType.isEmpty ||
+            (selectedType == "해주세요" && item.category == .request && item.mode == .service) ||
+            (selectedType == "할수있어요" && item.category == .provide && item.mode == .service) ||
+            (selectedType == "필요해요" && item.category == .request && item.mode == .item) ||
+            (selectedType == "팔아요" && item.category == .provide && item.mode == .item)
+            
+            return categoryMatches && typeMatches
         }
     }
-
+    
+    private func typeOptions(for category: String) -> [String] {
+        switch category {
+        case "서비스": return ["해주세요", "할수있어요"]
+        case "물건": return ["필요해요", "팔아요"]
+        default: return []
+        }
+    }
+    
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading) {
                 ZStack {
                     Text("내 글")
                         .gwangsanFont(style: .body1)
-
+                    
                     HStack {
                         Button(action: {
                             dismiss()
@@ -52,60 +62,66 @@ struct MyPostsView: View {
                     }
                 }
                 .padding(.bottom, 30)
-
+                
                 Text("카테고리 선택 후 내 글 확인")
                     .gwangsanFont(style: .titleSmall)
                     .padding(.bottom, 16)
-
+                
                 HStack(alignment: .top, spacing: 24) {
                     DropdownSelector(
                         options: ["서비스", "물건"],
                         placeholder: "선택",
                         selectedOption: $selectedCategory
                     )
-
+                    
                     DropdownSelector(
-                        options: ["해주세요", "팔아요"],
+                        options: typeOptions(for: selectedCategory),
                         placeholder: "선택",
                         selectedOption: $selectedType
                     )
                 }
-
+                .onChange(of: selectedCategory) { _ in
+                    selectedType = ""
+                }
+                
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         ForEach(filteredItems) { item in
-                            HStack(alignment: .center, spacing: 24) {
-                                Image(item.imageName)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 80, height: 80)
-                                    .clipped()
-                                    .cornerRadius(8)
-
-                                VStack(alignment: .leading, spacing: 12) {
-                                    Text(item.title)
-                                        .gwangsanFont(style: .body3)
-
-                                    Text("\(item.point) 광산")
-                                        .font(.system(size: 14))
+                            NavigationLink(destination: MyPostDetailView(item: item)) {
+                                HStack(alignment: .center, spacing: 24) {
+                                    Image(item.imageName)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fill)
+                                        .frame(width: 80, height: 80)
+                                        .clipped()
+                                        .cornerRadius(8)
+                                    
+                                    VStack(alignment: .leading, spacing: 12) {
+                                        Text(item.title)
+                                            .gwangsanFont(style: .body3)
+                                            .foregroundColor(.black)
+                                        
+                                        Text("\(item.point) 광산")
+                                            .font(.system(size: 14))
+                                            .foregroundColor(.black)
+                                    }
+                                    Spacer()
                                 }
-
-                                Spacer()
+                                .padding(.vertical, 16)
                             }
-                            .padding(.vertical, 16)
                         }
                     }
+                    .padding(.top, 24)
+                    
+                    Spacer()
                 }
-                .padding(.top, 24)
-
-                Spacer()
             }
-            .padding(.horizontal, 24)
+            .navigationBarHidden(true)
         }
-        .navigationBarHidden(true)
+        .padding(.horizontal, 24)
     }
 }
 
 #Preview {
-    MyPostsView()
+        MyPostsView()
 }

--- a/Projects/App/Sources/Feature/ProfileFeature/Views/TradeLogView.swift
+++ b/Projects/App/Sources/Feature/ProfileFeature/Views/TradeLogView.swift
@@ -8,42 +8,43 @@
 
 import SwiftUI
 
-struct TradeItem: Identifiable {
-    let id = UUID()
-    let imageName: String
-    let title: String
-    let point: Int
-    let category: String
-}
-
 struct TradeLogView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var selectedCategory = ""
     @State private var selectedType = ""
-    
-    let items: [TradeItem] = [
-        TradeItem(imageName: "TestImage1", title: "바퀴벌레 좀 잡아주세요", point: 3000, category: "서비스"),
-        TradeItem(imageName: "TestImage2", title: "집 청소좀 해주세요", point: 3000, category: "서비스"),
-        TradeItem(imageName: "TestImage3", title: "자전거 팔아요", point: 5000, category: "물건")
+
+    let items: [CommonItem] = [
+        CommonItem(id: UUID(), title: "바퀴벌레 좀 잡아주세요", point: 3000, category: .request, imageName: "TestImage1", content: "바퀴벌레 요청", mode: .service),
+        CommonItem(id: UUID(), title: "집 청소좀 해주세요", point: 3000, category: .request, imageName: "TestImage2", content: "집 청소 요청", mode: .service),
+        CommonItem(id: UUID(), title: "자전거 팔아요", point: 5000, category: .provide, imageName: "TestImage3", content: "자전거 판매", mode: .item)
     ]
 
-    var filteredItems: [TradeItem] {
+    var filteredItems: [CommonItem] {
         items.filter { item in
-            (selectedCategory.isEmpty || item.category == selectedCategory)
+            let categoryMatch = selectedCategory.isEmpty ||
+                (selectedCategory == "서비스" && item.mode == .service) ||
+                (selectedCategory == "물건" && item.mode == .item)
+
+            let typeMatch = selectedType.isEmpty ||
+                (selectedType == "해주세요" && item.category == .request && item.mode == .service) ||
+                (selectedType == "할수있어요" && item.category == .provide && item.mode == .service) ||
+                (selectedType == "필요해요" && item.category == .request && item.mode == .item) ||
+                (selectedType == "팔아요" && item.category == .provide && item.mode == .item)
+
+            return categoryMatch && typeMatch
         }
     }
-    
+
     var body: some View {
-        NavigationStack{
-            VStack(alignment: .leading){
+        NavigationStack {
+            VStack(alignment: .leading) {
+                // 상단 타이틀 및 뒤로가기
                 ZStack {
                     Text("거래 내역")
                         .gwangsanFont(style: .body1)
-                    
+
                     HStack {
-                        Button(action: {
-                            dismiss()
-                        }) {
+                        Button(action: { dismiss() }) {
                             Image(systemName: "chevron.left")
                                 .frame(width: 24, height: 24)
                                 .gwangsanColor(GwangsanAsset.Color.gray500)
@@ -52,24 +53,34 @@ struct TradeLogView: View {
                     }
                 }
                 .padding(.bottom, 30)
-                
+
+                // 드롭다운 필터
                 Text("카테고리 선택 후 내 거래내역 확인")
                     .gwangsanFont(style: .titleSmall)
                     .padding(.bottom, 16)
-                
+
                 HStack(alignment: .top, spacing: 24) {
                     DropdownSelector(
                         options: ["서비스", "물건"],
                         placeholder: "선택",
                         selectedOption: $selectedCategory
                     )
-                    
+
                     DropdownSelector(
-                        options: ["해주세요", "팔아요"],
+                        options: selectedCategory == "서비스"
+                            ? ["해주세요", "할수있어요"]
+                            : selectedCategory == "물건"
+                            ? ["필요해요", "팔아요"]
+                            : [],
                         placeholder: "선택",
                         selectedOption: $selectedType
                     )
                 }
+                .onChange(of: selectedCategory) { _ in
+                    selectedType = ""
+                }
+
+                // 목록 뷰
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         ForEach(filteredItems) { item in
@@ -97,9 +108,10 @@ struct TradeLogView: View {
                         }
                     }
                 }
+
+                Spacer()
             }
             .padding(.horizontal, 24)
-            Spacer()
         }
         .navigationBarHidden(true)
     }


### PR DESCRIPTION
## 💡 개요
프로필 페이지, 게시글 작성 페이지 수정

## 📃 작업내용
- 프로필 페이지의 내글 -> 내글디테일 뷰 퍼블리싱
- 게시글 작성 상단타이틀 변경
- 게시글 작성시 mode와 category 추가
- 프로필 페이지 거래목록 드롭다운 수정